### PR TITLE
Release/1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+**/*.terraform*
+**/*.tfstate*
+**/*.dev*
+
+crash.log
+
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/_config.tf
+++ b/_config.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+  }
+}

--- a/_out.tf
+++ b/_out.tf
@@ -28,6 +28,11 @@ output "repository" {
   value       = aws_ecr_repository.repo
 }
 
+output "repository_policy" {
+  description = "The repository policy used to manage access to this repository"
+  value       = aws_ecr_repository_policy.repo_policy
+}
+
 output "scan_on_push" {
   description = "The provided value for var.scan_on_push"
   value       = var.scan_on_push

--- a/_out.tf
+++ b/_out.tf
@@ -1,0 +1,46 @@
+output "image_tag_mutability" {
+  description = "The provided value for var.image_tag_mutability"
+  value       = var.image_tag_mutability
+}
+
+output "kms_key" {
+  description = "The provided value for var.kms_key"
+  value       = var.kms_key
+}
+
+output "name" {
+  description = "The provided value for var.name"
+  value       = var.name
+}
+
+output "read_principals" {
+  description = "The provided value for var.read_principals"
+  value       = var.read_principals
+}
+
+output "readwrite_principals" {
+  description = "The provided value for var.readwrite_principals"
+  value       = var.readwrite_principals
+}
+
+output "repository" {
+  description = "The repository object itself"
+  value       = aws_ecr_repository.repo
+}
+
+output "scan_on_push" {
+  description = "The provided value for var.scan_on_push"
+  value       = var.scan_on_push
+}
+
+output "tags" {
+  description = "Tags assigned to the repository"
+  value = merge(var.tags, {
+    "Managed By Terraform" = "true"
+  })
+}
+
+output "use_repository_policy" {
+  description = "The provided value for var.use_repository_policy"
+  value       = var.use_repository_policy
+}

--- a/_var.tf
+++ b/_var.tf
@@ -1,0 +1,46 @@
+variable "image_tag_mutability" {
+  description = "Whether changes can be pushed to existing tags on images in this repository (MUTABLE or IMMUTABLE)"
+  type        = string
+  default     = "MUTABLE"
+}
+
+variable "kms_key" {
+  description = "The arn of a KMS key that will be used to encrypt the contents of the repository"
+  type        = string
+  default     = null
+}
+
+variable "name" {
+  description = "The name of the repository"
+  type        = string
+}
+
+variable "read_principals" {
+  description = "ARNs of principals that are allowed to pull from this repository. Only used if use_repository_policy == true"
+  type        = list(string)
+  default     = []
+}
+
+variable "readwrite_principals" {
+  description = "ARNs of principals that are allowed to push and pull to/ from this repository. Only used if use_repository_policy == true"
+  type        = list(string)
+  default     = []
+}
+
+variable "scan_on_push" {
+  description = "Whether or not to scan images for vulnerabilities as they are uploaded to the repository"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to assign to the repository"
+  type        = map(string)
+  default     = {}
+}
+
+variable "use_repository_policy" {
+  description = "Whether or not to assign a repository policy to this repository, allowing granular access management"
+  type        = bool
+  default     = true
+}

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,0 +1,13 @@
+module "my_ecr_repo" {
+  source = "../"
+
+  name = "my-ecr-repo"
+
+  read_principals = [
+    "arn:aws:iam::111122223333:user/my-iam-user",
+  ]
+
+  readwrite_principals = [
+    "arn:aws:iam::111122223333:user/my-other-iam-user",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,29 @@
+resource "aws_ecr_repository" "repo" {
+  name                 = var.name
+  image_tag_mutability = var.image_tag_mutability
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = var.kms_key
+  }
+
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
+
+  tags = merge(var.tags, {
+    "Managed By Terraform" = "true"
+  })
+}
+
+resource "aws_ecr_repository_policy" "repo_policy" {
+  count = var.use_repository_policy ? 1 : 0
+
+  repository = aws_ecr_repository.repo.name
+  policy = templatefile("${path.module}/templates/repository-policy.json.tpl", {
+    read_principals              = length(var.read_principals) == 1 ? jsonencode(var.read_principals.0) : jsonencode(var.read_principals)
+    read_principals_enabled      = length(var.read_principals) > 0
+    readwrite_principals         = length(var.readwrite_principals) == 1 ? jsonencode(var.readwrite_principals.0) : jsonencode(var.readwrite_principals)
+    readwrite_principals_enabled = length(var.readwrite_principals) > 0
+  })
+}

--- a/templates/repository-policy.json.tpl
+++ b/templates/repository-policy.json.tpl
@@ -1,0 +1,32 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [%{ if read_principals_enabled }
+        {
+            "Sid": "AllowPull",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": ${read_principals}
+            },
+            "Action": [
+                "ecr:BatchGetImage",
+                "ecr:GetDownloadUrlForLayer"
+            ]
+        }%{ endif }%{ if read_principals_enabled && readwrite_principals_enabled },%{ endif }%{ if readwrite_principals_enabled }
+        {
+            "Sid": "AllowPushPull",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": ${readwrite_principals}
+            },
+            "Action": [
+                "ecr:BatchGetImage",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:CompleteLayerUpload",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:InitiateLayerUpload",
+                "ecr:PutImage",
+                "ecr:UploadLayerPart"
+            ]
+        }%{ endif }
+    ]
+}


### PR DESCRIPTION
Release/1.0.0

Makes an ECR repository, optionally with a repository policy for controlling read/readwrite access (on by default)

Repository contents are KMS-encrypted, optionally with a provided KMS key